### PR TITLE
add simple punctuation support

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,6 +45,10 @@ jobs:
         with:
           cache-on-failure: true
 
+      - name: Run tests
+        run: |
+          cargo test
+
       - name: Install trunk and wasm-bindgen-cli
         run: |
           cargo install trunk --version ~0.14 --locked


### PR DESCRIPTION
Closes: #10 

This adds *very* simple punctuation stripping, stripping all trailing punctuation and all preceding punctuation *except* for apostrophes (e.g. 'twas) works.

Note this fails to properly handle something like `'this is a test'`, in that it will try to process `'this` as a word. This is theoretically easy to handle, but requires a bit more logic than what I have here (e.g. maybe we do something where for words starting for an apostrophe, we try it first with, and if it fails, without).